### PR TITLE
ci: migrate CodeQL runner to self-hosted ARC fleet (develop)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Migrate the remaining non-self-hosted runner label in `.github/workflows/` to the self-hosted ARC fleet.

- `codeql.yml`: analyze job `ubuntu-latest` -> `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (CodeQL/security scan -> smallest _4 pool per policy).

`pulumi.yml` already uses `RUNNER_LINUX_X64_4` on develop, so it is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)