### PR TITLE
ci: migrate Pulumi runner to self-hosted ARC fleet (master)

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     name: Update
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Migrate the non-self-hosted runner label in `.github/workflows/` to the self-hosted ARC fleet.

- `pulumi.yml`: deploy job `ubuntu-latest` -> `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (deploy job -> _4 pool per policy). Mirrors the already-migrated develop branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)